### PR TITLE
docker: replace ganache with geth

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -7,7 +7,7 @@ services:
       context: ./integration-tests
       dockerfile: Dockerfile.dev
     volumes:
-      - ./integration-tests:/mnt
+      - ./:/mnt
     env_file:
       - docker-compose.env
 
@@ -23,8 +23,8 @@ services:
       - docker-compose.env
 
   l1_chain:
-    image: trufflesuite/ganache-cli:latest
-    entrypoint: node /app/ganache-core.docker.cli.js -p 9545 --gasPrice="0x0" --callGasLimit="0x1fffffffffffff" --gasLimit="0x1fffffffffffff" --account="0xdf8b81d840b9cafc8cd68cf94f093726b174b5f109eba11a3f2a559e5f9e8bce,1000000000000000000000" --account="0x06caa6f48604a58872e27db8c2980584e20faab37613f51383bb5be62db80c50,100000000000000000000"
+    image: ethereum/client-go:latest
+    entrypoint: geth --nousb --dev --http --miner.gasprice 0 --txpool.pricelimit 0 --http.addr '0.0.0.0' --http.port 9545 --ws --ws.addr '0.0.0.0' --ws.port 9545 --http.api='admin,debug,web3,eth,txpool,personal,clique,net' --gcmode=archive --http.vhosts='*' --http.corsdomain='*' --verbosity=6 --dev.period='0'
     ports:
       - 9545:9545
 
@@ -45,7 +45,7 @@ services:
       dockerfile: Dockerfile.dev
     volumes:
       - l2-node-data:/mnt/l2-node/l2:rw
-      - ./go-ethereum:/mnt/go-ethereum
+      - ./:/mnt
     env_file:
       - docker-compose.env
     ports:


### PR DESCRIPTION
This is an experiment to use geth for the L1 chain instead of ganache