### PR TITLE
Fix Geth local build

### DIFF
--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -12,15 +12,17 @@ services:
     entrypoint: ["sh", "-c", "yarn && yarn build"]
 
   geth_l2:
-    image: ethereumoptimism/builder:master
+    build:
+      context: ./docker/go-ethereum
+      dockerfile: Dockerfile.build
     volumes:
-      - ./:/mnt
+      - ./go-ethereum:/go-ethereum
     env_file:
       - docker-compose.env
     ports:
       - 8545:8545
+    working_dir: /go-ethereum
     entrypoint: ["make", "geth"]
-    working_dir: /mnt/go-ethereum
 
   batch_submitter:
     image: ethereumoptimism/builder:master

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,22 +1,56 @@
 ######### L2 GETH VARS #########
-TARGET_GAS_LIMIT
-VOLUME_PATH=/l2-node/l2
+VOLUME_PATH=/l2-node/l2 # TODO: double check this isn't used
 HOSTNAME=geth_l2
 PORT=8545
+
 NETWORK_ID=420
-TX_INGESTION=true
-TX_INGESTION_DB_HOST=postgres
-TX_INGESTION_POLL_INTERVAL='1s'
+DEV=true
+DATADIR=/l2-node/l2
+RPC_ENABLE=true
+RPC_ADDR=geth_l2
+RPC_CORS_DOMAIN='*'
+RPC_VHOSTS='*'
+RPC_PORT=8545
+WS=true
+WS_ADDR=0.0.0.0
+IPC_DISABLE=true
+TARGET_GAS_LIMIT=8000000
+RPC_API='eth,net,rollup'
+WS_API='eth,net,rollup'
+WS_ORIGINS='*'
+GASPRICE=0
+NO_USB=true
+GCMODE=archive
+NO_DISCOVER=true
+
+ETH1_SYNC_SERVICE_ENABLE=true
+ETH1_CTC_DEPLOYMENT_HEIGHT=1
+ETH1_HTTP=ws://l1_chain:9545
+
+DEPLOYER_HTTP=http://deployer:8080
+
+# used by hardhat
+ETH1_HTTP_PORT=9545
+# used by hardhat and integration tests
+MNEMONIC='abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+# used by deployer
+HARDHAT=true
 
 ######### Batch Submitter #########
 # Logging
 # The comma-separated logging patterns to match (common options are `error*`, `info*`, `warn*`, and `debug*`)
 DEBUG=info*,error*,warn*,debug*
 
-# L1 Node
-# The URL of the L1 node
-L1_NODE_WEB3_URL=http://l1_chain:9545
+# keys are derived from the mnemonic above
+DEPLOYER_PRIVATE_KEY=0x754fde3f5e60ef2c7649061e06957c29017fe21032a8017132c0078e37f6193a
+SEQUENCER_PRIVATE_KEY=0xd2ab07f7c10ac88d5f86f1b4c1035d5195e81f27dbe62ad65e59cbf88205629b
+MAX_TX_SIZE=10000
+POLL_INTERVAL=15000
+DEFAULT_BATCH_SIZE=1000
+NUM_CONFIRMATIONS=1
+RUN_TX_BATCH_SUBMITTER=true
+RUN_STATE_BATCH_SUBMITTER=false
 
-# L2 Node
-# The URL of the L2 node
+L1_NODE_WEB3_URL=http://l1_chain:9545
 L2_NODE_WEB3_URL=http://geth_l2:8545

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,24 +3,22 @@ version: "3"
 services:
 
   integration_tests:
-    image: ethereumoptimism/integration-tests:latest
+    image: ethereumoptimism/integration-tests:docker-entrypoint-new
     volumes:
       - ./integration-tests:/integration-tests
+      - ./docker/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh:/integration-tests/wait.sh
     env_file:
       - docker-compose.env
     environment:
-      - "PKGS=${PKGS}"
+      - "PKGS=integration-tests"
 
   l1_chain:
-    image: ethereumoptimism/ganache-cli:latest
-    entrypoint: node /app/ganache-core.docker.cli.js -p 9545 --gasPrice="0x0" --callGasLimit="0x1fffffffffffff" --gasLimit="0x1fffffffffffff" --account="0xdf8b81d840b9cafc8cd68cf94f093726b174b5f109eba11a3f2a559e5f9e8bce,1000000000000000000000" --account="0x06caa6f48604a58872e27db8c2980584e20faab37613f51383bb5be62db80c50,100000000000000000000" --db /mnt/db
+    image: ethereumoptimism/hardhat:master
     ports:
       - 9545:9545
-    volumes:
-    - ganache:/mnt/db:rw
 
   geth_l2:
-    image: ethereumoptimism/go-ethereum:latest
+    image: ethereumoptimism/go-ethereum:docker-entrypoint-new
     volumes:
     - ./:/mnt
     - geth:/l2-node/l2:rw
@@ -30,14 +28,19 @@ services:
       - docker-compose.env
     ports:
       - 8545:8545
+    entrypoint: ["/bin/wait-for-l1.sh", "geth", "--verbosity=6"]
 
   batch_submitter:
-    image: ethereumoptimism/batch-submitter:latest
+    image: ethereumoptimism/batch-submitter:master
     env_file:
       - docker-compose.env
     volumes:
      - ./optimism-monorepo:/opt/optimism-monorepo
 
+  deployer:
+    image: ethereumoptimism/deployer:master
+    env_file:
+      - docker-compose.env
+
 volumes:
-  ganache:
   geth:

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
 
   integration_tests:
-    image: ethereumoptimism/integration-tests:docker-entrypoint-new
+    image: ethereumoptimism/integration-tests:latest
     volumes:
       - ./integration-tests:/integration-tests
       - ./docker/integration-tests/wait-for-l1-and-l2-and-contract-deployment.sh:/integration-tests/wait.sh
@@ -18,17 +18,16 @@ services:
       - 9545:9545
 
   geth_l2:
-    image: ethereumoptimism/go-ethereum:docker-entrypoint-new
+    image: ethereumoptimism/go-ethereum:latest
     volumes:
-    - ./:/mnt
-    - geth:/l2-node/l2:rw
-    # Mount the locally built geth earlier in the PATH
-    - ./go-ethereum/build/bin/geth:/usr/local/sbin/geth
+      - ./go-ethereum:/go-ethereum
+      - ./docker/deployer/wait-for-l1.sh:/bin/wait-for-l1.sh
     env_file:
       - docker-compose.env
     ports:
       - 8545:8545
-    entrypoint: ["/bin/wait-for-l1.sh", "geth", "--verbosity=6"]
+    working_dir: /go-ethereum
+    entrypoint: ["/bin/wait-for-l1.sh", "/go-ethereum/build/bin/geth", "--verbosity=6"]
 
   batch_submitter:
     image: ethereumoptimism/batch-submitter:master

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,34 +3,43 @@ version: "3"
 services:
 
   integration_tests:
-    image: ethereumoptimism/integration-tests:latest
+    #image: ethereumoptimism/integration-tests:master
+    image: ethereumoptimism/integration-tests:docker-entrypoint-new
     env_file:
-      - docker-compose.env
+      - ./docker-compose.env
     environment:
-      - "PKGS=${PKGS}"
+      - "PKGS=integration-tests"
+      #- "PKGS=${PKGS}"
 
   l1_chain:
-    image: ethereumoptimism/ganache-cli:latest
-    entrypoint: node /app/ganache-core.docker.cli.js -p 9545 --gasPrice="0x0" --callGasLimit="0x1fffffffffffff" --gasLimit="0x1fffffffffffff" --account="0xdf8b81d840b9cafc8cd68cf94f093726b174b5f109eba11a3f2a559e5f9e8bce,1000000000000000000000" --account="0x06caa6f48604a58872e27db8c2980584e20faab37613f51383bb5be62db80c50,100000000000000000000" --db /mnt/db
+    image: ethereumoptimism/hardhat:master
     ports:
       - 9545:9545
-    volumes:
-      - ganache:/mnt/db:rw
+    env_file:
+      - ./docker-compose.env
 
   geth_l2:
-    image: ethereumoptimism/go-ethereum:latest
+    #image: ethereumoptimism/go-ethereum:master
+    image: ethereumoptimism/go-ethereum:docker-entrypoint-new
     volumes:
       - geth:/l2-node/l2:rw
     env_file:
-      - docker-compose.env
+      - ./docker-compose.env
     ports:
       - 8545:8545
+    entrypoint: ["/bin/wait-for-l1.sh", "geth", "--verbosity=6"]
 
   batch_submitter:
-    image: ethereumoptimism/batch-submitter:latest
+    image: ethereumoptimism/batch-submitter:master
     env_file:
-      - docker-compose.env
+      - ./docker-compose.env
+
+  deployer:
+    image: ethereumoptimism/deployer:master
+    env_file:
+      - ./docker-compose.env
+    ports:
+      - 8080:8080
 
 volumes:
   geth:
-  ganache:

--- a/test.sh
+++ b/test.sh
@@ -30,7 +30,7 @@ else
             | xargs docker volume rm 2&>/dev/null
 
         PKGS=$PKGS \
-            docker-compose -f docker-compose.local.yml \
+            docker-compose -f docker-compose.yml \
                 --env-file docker-compose.microservices.env \
                 up \
                 --exit-code-from integration_tests \

--- a/up.sh
+++ b/up.sh
@@ -3,7 +3,7 @@
 # Start the services without all of the microservices
 # or running the integration tests
 
-SERVICES='geth_l2 l1_chain batch_submitter'
+SERVICES='geth_l2 l1_chain batch_submitter deployer'
 
 docker-compose -f docker-compose.yml rm -f
 docker volume ls \


### PR DESCRIPTION
It seems the problem with our local builds were that:

1. The build container was not producing compatible binaries for alpine linux.
2. The docker-compose.local.yml was using the _native_ geth, not the geth binary that was mounted.

To fix this I:
1. Added a Dockerfile.build which is able to build alpine compatible binaries.
2. Updated the docker-file.build.yml to point to that build Dockerfile for building geth_l2.
3. Updated docker-compose.local.yml to point at the mounted geth