### PR TITLE
Prevent redownloading of geth deps if they already exist on local machine

### DIFF
--- a/build-local.sh
+++ b/build-local.sh
@@ -51,7 +51,11 @@ done
 docker-compose -f docker-compose.build.yml down --remove-orphans
 
 # Remove all volumes except for the go-modules volume
-docker volume ls --format='{{.Name}}' | grep optimism-integration | grep -v go-modules | xargs docker volume rm -f
+docker volume ls --format='{{.Name}}' \
+  | grep optimism-integration \
+  | grep -v go-modules \
+  | xargs docker volume rm -f \
+  > /dev/null 2>&1
 
 if [ -z $SERVICE ]; then
     for SERVICE in $SERVICES; do

--- a/build-local.sh
+++ b/build-local.sh
@@ -48,7 +48,10 @@ while (( "$#" )); do
   esac
 done
 
-docker-compose -f docker-compose.build.yml down -v --remove-orphans
+docker-compose -f docker-compose.build.yml down --remove-orphans
+
+# Remove all volumes except for the go-modules volume
+docker volume ls --format='{{.Name}}' | grep optimism-integration | grep -v go-modules | xargs docker volume rm -f
 
 if [ -z $SERVICE ]; then
     for SERVICE in $SERVICES; do

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,7 +1,9 @@
 version: "3"
 
-services:
+volumes:
+  go-modules: # Define a volume for Go modules
 
+services:
   integration_tests:
     image: ethereumoptimism/builder:master
     volumes:
@@ -15,7 +17,7 @@ services:
     image: ethereumoptimism/builder:master
     volumes:
       - ./:/mnt
-      - $GOPATH/pkg/mod:/go/pkg/mod
+      - go-modules:/go/pkg/mod # Put modules cache into a separate volume
     env_file:
       - docker-compose.env
     ports:

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -15,6 +15,7 @@ services:
     image: ethereumoptimism/builder:master
     volumes:
       - ./:/mnt
+      - $GOPATH/pkg/mod:/go/pkg/mod
     env_file:
       - docker-compose.env
     ports:

--- a/docker-compose.env
+++ b/docker-compose.env
@@ -1,3 +1,6 @@
+######### GO #########
+GOPATH=/go
+
 ######### L2 GETH VARS #########
 CHAIN_ID=420
 NETWORK_ID=420

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,7 +1,9 @@
 version: "3"
 
-services:
+volumes:
+  go-modules: # Define a volume for Go modules
 
+services:
   integration_tests:
     image: ethereumoptimism/integration-tests:${INTEGRATION_TESTS_TAG:-latest}
     volumes:
@@ -24,8 +26,8 @@ services:
     volumes:
     - ./:/mnt
     - geth:/l2-node/l2:rw
-    # Mount the locally built geth earlier in the PATH
-    - ./go-ethereum/build/bin/geth:/usr/local/sbin/geth
+    - go-modules:/go/pkg/mod # Put modules cache into a separate volume
+    - ./go-ethereum/build/bin/geth:/usr/local/sbin/geth # Mount the locally built geth earlier in the PATH
     env_file:
       - docker-compose.env
     ports:


### PR DESCRIPTION
This is a slight optimization of the geth build in docker so that deps are not redownloaded if they already have been. I explored optimizing the build further via simply running `go install github.com/ethereum/go-ethereum/cmd/geth` instead of `make geth` as mentioned here https://geth.ethereum.org/docs/install-and-build/build-from-source, but it appears this runs the same process under the hood except with the verbose flag as can be seen in the console output:

` >>> /usr/local/go-1.13/bin/go install -v ./cmd/geth` that is generated by the `MustRun` method within the `ci.go` file in go-ethereum so I'm afraid I don't see a nontrivial way to speed up the geth build time much more than beyond this minor improvement.