### PR TITLE
Enable directory listing for deployer locally

### DIFF
--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -42,6 +42,8 @@ services:
     image: ethereumoptimism/deployer:${DEPLOYER_TAG:-latest}
     env_file:
       - docker-compose.env
+    ports:
+      - 8080:8080
 
 volumes:
   geth:


### PR DESCRIPTION
Just opens up a port to view the deployer's json files in a directory listing. Useful for debugging locally.