### PR TITLE
relayer: add to up script

### DIFF
--- a/up-verifier.sh
+++ b/up-verifier.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 DOCKERFILE='docker-compose.local.yml'
-SERVICES="up deployer verifier l1_chain batch_submitter geth_l2"
+SERVICES="deployer verifier l1_chain batch_submitter geth_l2"
 
 while (( "$#" )); do
   case "$1" in
@@ -30,4 +30,4 @@ docker-compose \
     -f $DOCKERFILE \
     -f optional/verifier-service.yml \
     -f optional/verifier-service.local.yml \
-    $SERVICES
+    up $SERVICES

--- a/up.sh
+++ b/up.sh
@@ -4,7 +4,8 @@
 # The `-s` flag takes a string of services to run.
 # The `-l` flag will use mounted code.
 
-SERVICES='geth_l2 l1_chain batch_submitter deployer'
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
+SERVICES='geth_l2 l1_chain batch_submitter deployer message_relayer'
 DOCKERFILE="docker-compose.yml"
 
 while (( "$#" )); do
@@ -24,6 +25,12 @@ while (( "$#" )); do
   esac
 done
 
-docker-compose -f $DOCKERFILE down -v --remove-orphans
-docker-compose -f $DOCKERFILE \
-  up $SERVICES
+docker-compose \
+    -f $DIR/$DOCKERFILE \
+    -f $DIR/optional/tx-ingestion-service.yml \
+    down -v --remove-orphans
+
+docker-compose \
+    -f $DOCKERFILE \
+    -f $DIR/optional/tx-ingestion-service.yml \
+    up $SERVICES

--- a/up.sh
+++ b/up.sh
@@ -31,6 +31,6 @@ docker-compose \
     down -v --remove-orphans
 
 docker-compose \
-    -f $DOCKERFILE \
+    -f $DIR/$DOCKERFILE \
     -f $DIR/optional/tx-ingestion-service.yml \
     up $SERVICES


### PR DESCRIPTION
Adds the relayer to the `up.sh` script, this depends on the docker-compose file for `tx-ingestion` test suite to not change which i don't think it will