### PR TITLE
up-verifier: more flexible

### DIFF
--- a/up-verifier.sh
+++ b/up-verifier.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Run the verifier along with the sequencer using
+# docker-compose
+
 DOCKERFILE='docker-compose.yml'
 SERVICES='deployer verifier l1_chain batch_submitter geth_l2'
 LOCAL_VERIFIER=

--- a/up-verifier.sh
+++ b/up-verifier.sh
@@ -1,12 +1,22 @@
 #!/bin/bash
 
-DOCKERFILE='docker-compose.local.yml'
-SERVICES="deployer verifier l1_chain batch_submitter geth_l2"
+DOCKERFILE='docker-compose.yml'
+SERVICES='deployer verifier l1_chain batch_submitter geth_l2'
+LOCAL_VERIFIER=
 
 while (( "$#" )); do
   case "$1" in
     -l|--local)
       DOCKERFILE="docker-compose.local.yml"
+      LOCAL_VERIFIER=true
+      shift 1
+      ;;
+    --local-sequencer)
+      DOCKERFILE="docker-compose.local.yml"
+      shift 1
+      ;;
+    --local-verifier)
+      LOCAL_VERIFIER=true
       shift 1
       ;;
     -s|--services)
@@ -20,14 +30,20 @@ while (( "$#" )); do
   esac
 done
 
-docker-compose \
-    -f $DOCKERFILE \
-    -f optional/verifier-service.yml \
-    -f optional/verifier-service.local.yml \
-    down -v --remove-orphans
+dcmd="docker-compose"
+dcmd="$dcmd -f $DOCKERFILE"
+dcmd="$dcmd -f optional/verifier-service.yml"
+if [ ! -z $LOCAL_VERIFIER ]; then
+    dcmd="$dcmd -f optional/verifier-service.local.yml"
+fi
+dcmd="$dcmd down -v --remove-orphans"
+$dcmd
 
-docker-compose \
-    -f $DOCKERFILE \
-    -f optional/verifier-service.yml \
-    -f optional/verifier-service.local.yml \
-    up $SERVICES
+cmd="docker-compose"
+cmd="$cmd -f $DOCKERFILE"
+cmd="$cmd -f optional/verifier-service.yml"
+if [ ! -z $LOCAL_VERIFIER ]; then
+    cmd="$cmd -f optional/verifier-service.local.yml"
+fi
+cmd="$cmd up $SERVICES"
+exec $cmd


### PR DESCRIPTION
Makes the `up-verifier` script more flexible so that it can run the sequencer locally, the verifier locally or both locally