### PR TITLE
up: log branch/commit hash when running locally

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -29,16 +29,18 @@ done
 
 
 function branch() {
-    cd $1
-    BRANCH=$(git branch --show-current)
-    COMMIT=$(git rev-parse --short HEAD)
+    BRANCH=$(git --git-dir $DIR/$1 branch --show-current)
+    COMMIT=$(git --git-dir $DIR/$1 rev-parse --short HEAD)
     echo "$1 $BRANCH $COMMIT"
 }
 
 if [ ! -z "$IS_LOCAL" ]; then
-    (branch go-ethereum)
-    (branch optimism-monorepo)
-    (branch integration-tests)
+    git submodule foreach \
+        '
+            BRANCH=$(git branch --show-current)
+            COMMIT=$(git rev-parse --short HEAD)
+            echo "$BRANCH $COMMIT"
+        '
 fi
 
 docker-compose \

--- a/up.sh
+++ b/up.sh
@@ -7,11 +7,13 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 SERVICES='geth_l2 l1_chain batch_submitter deployer message_relayer data_transport_layer'
 DOCKERFILE="docker-compose.yml"
+IS_LOCAL=
 
 while (( "$#" )); do
   case "$1" in
     -l|--local)
       DOCKERFILE="docker-compose.local.yml"
+      IS_LOCAL=true
       shift 1
       ;;
     -s|--services)
@@ -24,6 +26,20 @@ while (( "$#" )); do
       ;;
   esac
 done
+
+
+function branch() {
+    cd $1
+    BRANCH=$(git branch --show-current)
+    COMMIT=$(git rev-parse --short HEAD)
+    echo "$1 $BRANCH $COMMIT"
+}
+
+if [ ! -z "$IS_LOCAL" ]; then
+    (branch go-ethereum)
+    (branch optimism-monorepo)
+    (branch integration-tests)
+fi
 
 docker-compose \
     -f $DIR/$DOCKERFILE \


### PR DESCRIPTION
Logs the branch/commit hash when using the `up.sh` script with the local flag. This makes it easier to debug around versioning of the different pieces of software running