### PR TITLE
batch-submitter: add to own repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "docker"]
 	path = docker
 	url = git@github.com:ethereum-optimism/docker.git
+[submodule "batch-submitter"]
+	path = batch-submitter
+	url = https://github.com/ethereum-optimism/batch-submitter

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = git@github.com:ethereum-optimism/docker.git
 [submodule "batch-submitter"]
 	path = batch-submitter
-	url = https://github.com/ethereum-optimism/batch-submitter
+	url = git@github.com:ethereum-optimism/batch-submitter.git

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -31,5 +31,5 @@ services:
       - docker-compose.env
     volumes:
       - ./:/mnt
-    working_dir: /mnt/optimism-monorepo
+    working_dir: /mnt/batch-submitter
     entrypoint: ["sh", "-c", "yarn && yarn build"]

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -35,7 +35,7 @@ services:
     env_file:
       - docker-compose.env
     volumes:
-     - ./optimism-monorepo:/opt/optimism-monorepo
+     - ./batch-submitter:/opt/batch-submitter
 
   deployer:
     image: ethereumoptimism/deployer:${DEPLOYER_TAG:-latest}


### PR DESCRIPTION
Adds the batch-submitter as a git submodule, updates the build local script to use the new batch-submitter

https://github.com/ethereum-optimism/batch-submitter