### PR TITLE
up.sh: warn on old version of docker-compose

### DIFF
--- a/up.sh
+++ b/up.sh
@@ -4,6 +4,15 @@
 # The `-s` flag takes a string of services to run.
 # The `-l` flag will use mounted code.
 
+VERSION=$(docker-compose --version)
+node -e "
+const version = '$VERSION'.match(/([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+)?/);
+if (version !== null) {
+  if (version[2] < 27 || version[3] < 3) {
+    console.log('Warning, update docker-compose')
+  }
+}"
+
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 SERVICES='geth_l2 l1_chain batch_submitter deployer message_relayer data_transport_layer'
 DOCKERFILE="docker-compose.yml"


### PR DESCRIPTION
This adds a dependency on `node` but prints a warning if the `docker-compose` is too old