### PR TITLE
Fix ordering of pull to first update repo

### DIFF
--- a/pull.sh
+++ b/pull.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-docker-compose pull
 git pull --recurse-submodules
+docker-compose pull


### PR DESCRIPTION
Quick fix that changes the order of our pull. This covers the case that we use `pull` and it doesn't download all of the images we need because in a future commit we have added/changed/removed a docker-compose service.