### PR TITLE
Store logs for integration tests as artifacts on CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Test
         run: |
-          bash test.sh
+          bash test.sh --suppress-output
 
       - name: Upload Log Artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -25,3 +25,9 @@ jobs:
       - name: Test
         run: |
           bash test.sh
+
+      - name: Upload Log Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: integration-test-artifacts
+          path: ./artifacts

--- a/test.sh
+++ b/test.sh
@@ -64,7 +64,6 @@ function run {
     cmd="$cmd up"
     cmd="$cmd --exit-code-from integration_tests"
     cmd="$cmd --abort-on-container-exit"
-    cmd="$cmd --no-color"
 
     echo "Logs available per-service at $artifacts_folder"
 
@@ -82,8 +81,10 @@ function run {
         # Send all process logs to artifacts folder w/ service name as filename
         # Delimiter based on | which docker-compose uses in streamed logs
         cd $artifacts_folder
-        cat process.log | grep -e "|"  \
-            | awk '{
+        cat process.log |
+            perl -pe 's/\x1b\[[0-9;]*[mG]//g' | # Remove bash color characters
+            grep -e "|" | # Only get log lines
+            awk '{
                 delimiter_idx = index($0, "| ");
                 service_name = substr($0, 0, delimiter_idx);
                 gsub("[^a-zA-Z0-9_]", "", service_name);

--- a/test.sh
+++ b/test.sh
@@ -76,7 +76,7 @@ function run {
     INTEGRATION_TESTS_TAG=$INTEGRATION_TESTS_TAG \
     MESSAGE_RELAYER_TAG=$MESSAGE_RELAYER_TAG \
     DATA_TRANSPORT_LAYER_TAG=$DATA_TRANSPORT_LAYER_TAG \
-        $cmd &> $artifacts_folder/process.log # Send all process logs to process.log
+        $cmd 2>&1 | tee $artifacts_folder/process.log # Send all process logs to process.log
 
     (
         # Send all process logs to artifacts folder w/ service name as filename

--- a/test.sh
+++ b/test.sh
@@ -76,7 +76,7 @@ function run {
     INTEGRATION_TESTS_TAG=$INTEGRATION_TESTS_TAG \
     MESSAGE_RELAYER_TAG=$MESSAGE_RELAYER_TAG \
     DATA_TRANSPORT_LAYER_TAG=$DATA_TRANSPORT_LAYER_TAG \
-        $cmd > $artifacts_folder/process.log # Send all process logs to process.log
+        $cmd &> $artifacts_folder/process.log # Send all process logs to process.log
 
     (
         # Send all process logs to artifacts folder w/ service name as filename

--- a/test.sh
+++ b/test.sh
@@ -83,14 +83,14 @@ function run {
         # Delimiter based on | which docker-compose uses in streamed logs
         cd $artifacts_folder
         cat process.log | grep -e "|"  \
-          | awk '{
-            idx = index($0, "| ");                  # Assign index of delimiter between service and log
-            service = substr($0, 0, idx);           # Assign variable for service
-            gsub("[^a-zA-Z0-9_]", "", service);     # Substitute any unnatural characters (e.g., spaces)
-            gsub("$", ".log", service);             # Add .log to end of variable (e.g., l1_chain.log)
-            outputfile = sprintf (service);         # Assign output file name to variable
-            print substr($0, idx + 2) > outputfile; # Send corresponding log to corresponding log file
-          }'
+            | awk '{
+                delimiter_idx = index($0, "| ");
+                service_name = substr($0, 0, delimiter_idx);
+                gsub("[^a-zA-Z0-9_]", "", service_name);
+                gsub("$", ".log", service_name);
+                outputfile = sprintf (service_name);
+                print substr($0, delimiter_idx + 2) > outputfile;
+            }'
     )
 
 }

--- a/test.sh
+++ b/test.sh
@@ -51,6 +51,10 @@ DATA_TRANSPORT_LAYER_TAG=$(echo $DATA_TRANSPORT_LAYER_TAG | sed 's/\//_/g')
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 
 function run {
+    # Create artifacts folder for logs
+    artifacts_folder="./artifacts/$PKGS"
+    mkdir -p $artifacts_folder
+
     local cmd
     cmd="docker-compose -f $DIR/$DOCKERFILE"
     cmd="$cmd -f $DIR/docker-compose.env.yml"
@@ -60,6 +64,9 @@ function run {
     cmd="$cmd up"
     cmd="$cmd --exit-code-from integration_tests"
     cmd="$cmd --abort-on-container-exit"
+    cmd="$cmd --no-color"
+
+    echo "Logs available per-service at $artifacts_folder"
 
     PKGS=$PKGS \
     DEPLOYER_TAG=$DEPLOYER_TAG \
@@ -69,7 +76,20 @@ function run {
     INTEGRATION_TESTS_TAG=$INTEGRATION_TESTS_TAG \
     MESSAGE_RELAYER_TAG=$MESSAGE_RELAYER_TAG \
     DATA_TRANSPORT_LAYER_TAG=$DATA_TRANSPORT_LAYER_TAG \
-        $cmd
+        $cmd > $artifacts_folder/process.log # Send all process logs to process.log
+
+    # Send all process logs to artifacts folder w/ service name as filename
+    cat $artifacts_folder/process.log | grep -e "|" | \
+      # Delimiter based on | which docker-compose uses in streamed logs
+      awk '{
+        idx = index($0, "| ");                  # Assign index of delimiter between service and log
+        service = substr($0, 0, idx);           # Assign variable for service
+        gsub("[^a-zA-Z0-9_]", "", service);     # Substitute any unnatural characters (e.g., spaces)
+        gsub("$", ".log", service);             # Add .log to end of variable (e.g., l1_chain.log)
+        outputfile = sprintf (service);         # Assign output file name to variable
+        print substr($0, idx + 2) > outputfile; # Send corresponding log to corresponding log file
+      }'
+
 }
 
 function clean {


### PR DESCRIPTION
Stores the logs per service (plucked from the inferred combines `docker-compose` configuration) for running the integration tests using Github Actions artifacts server.

**Motivation**
It's difficult to parse the logs on the CI. For example, here is a random selection from [this run](https://github.com/ethereum-optimism/optimism-integration/runs/2028659701):

```
geth_l2_1               | DEBUG[03-04|06:39:09.971] Miner got new head                       height=7 block-hash=0x5821d3e1dfbaa92cd2d9e59da2fb6a1c94741ee906825cf3a34744c1fdc9577d tx-hash=0x8f4ae5d938b3c66793614cebcb4730be3a8892a3aee3cd021d090f08d7bacbb9 tx-hash=0x8f4ae5d938b3c66793614cebcb4730be3a8892a3aee3cd021d090f08d7bacbb9
geth_l2_1               | DEBUG[03-04|06:39:09.973] Served eth_getTransactionByHash          conn=172.18.0.3:53814 reqid=71 t=271.201µs
geth_l2_1               | DEBUG[03-04|06:39:09.976] Served eth_chainId                       conn=172.18.0.3:53816 reqid=72 t=12.1µs
geth_l2_1               | DEBUG[03-04|06:39:09.978] Served eth_getTransactionReceipt         conn=172.18.0.3:53818 reqid=73 t=391.102µs
integration_tests_1     |  |     ✓ should sequencer batch append (47ms)
integration_tests_1     |  | 
integration_tests_1     |  | 
integration_tests_1     |  |   3 passing (17s)
integration_tests_1     |  | 
integration_tests_1     | Done in 24.29s.
optimism-integration_integration_tests_1 exited with code 0
Stopping optimism-integration_data_transport_layer_1 ... 
Stopping optimism-integration_l1_chain_1             ... 
Stopping optimism-integration_deployer_1             ... 
Stopping optimism-integration_batch_submitter_1      ... 
Stopping optimism-integration_geth_l2_1              ... 
Stopping optimism-integration_data_transport_layer_1 ... done
```

The logs are:
- Combining every service into one output
- Very difficult to parse using the UI (e.g., the DOM can take many seconds to render or crash the tab)
- Still difficult to parse even if downloaded, as you then need to do manual parsing per service (e.g., using `grep`)

**Solution**

This solution does two things.

1. Redirects the output from the `docker-compose up` command to a single file, `process.log` per test package
2. Splits the logs per `process.log` into separate log files per service, with the log prefix pre-prended by `docker-compose` removed

For example:
```
artifacts
└── tx-ingestion
    ├── batch_submitter_1.log
    ├── data_transport_layer_1.log
    ├── deployer_1.log
    ├── geth_l2_1.log
    ├── integration_tests_1.log
    ├── l1_chain_1.log
    └── process.log
```

Conveniently, this does not add any hard-coded service names to the infrastructure or test files, and will infer all of these files strictly from the output of `docker-compose up`.