### PR TITLE
ci: fix for arbitrary branches

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,9 +22,13 @@ jobs:
           git submodule init
           git submodule update
 
+      - name: Build
+        run: |
+          make all
+
       - name: Test
         run: |
-          bash test.sh --suppress-output
+          ./test.sh -l --suppress-output
 
       - name: Upload Log Artifacts
         uses: actions/upload-artifact@v2

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 .PHONY: all integration-tests deployer geth-l2 batch-submitter data-transport-layer test
 
+SHELL := /bin/bash
+
 all:
 	@echo "Building in parallel in the background"
 	./build-local.sh
-	@while :; do [[ $$(docker ps --format='{{.Image}}' | grep builder | wc -l) == 0 ]] && exit 0; sleep 2; done;
+	@while :; do [ $$(docker ps --format='{{.Image}}' | grep builder | wc -l) == 0 ] && exit 0; sleep 2; done;
 
 up-local:
 	./up.sh -l


### PR DESCRIPTION
Allows the CI to run with arbitrary branches, this is because of the `-l` flag passed to `test.sh`